### PR TITLE
Remove QCA again...

### DIFF
--- a/quassel/quassel/quassel.py
+++ b/quassel/quassel/quassel.py
@@ -44,7 +44,7 @@ class subinfo(info.infoclass):
         self.runtimeDependencies["qt-libs/snorenotify"] = "default"
         self.runtimeDependencies["libs/zlib"] = "default"
         self.runtimeDependencies["libs/openssl"] = "default"
-        self.runtimeDependencies["kdesupport/qca"] = "default"
+        # self.runtimeDependencies["kdesupport/qca"] = "default"
         self.runtimeDependencies["dev-utils/pkg-config"] = "default"
         self.runtimeDependencies["libs/qt5/qtbase"] = "default"
         self.runtimeDependencies["libs/qt5/qtwebengine"] = "default"


### PR DESCRIPTION
Seems like the QCA blueprint is still broken, so disable the dependency
for now.