### PR TITLE
Don't install .lib files in bin/

### DIFF
--- a/quassel/quassel/quassel.py
+++ b/quassel/quassel/quassel.py
@@ -62,7 +62,7 @@ class Package(CMakePackageBase):
         self.subinfo.options.configure.args = " -DUSE_QT5=ON"
         if OsUtils.isWin():
             self.subinfo.options.configure.args += (" -DCMAKE_INSTALL_BINDIR=bin"
-                                                    " -DCMAKE_INSTALL_LIBDIR=bin"
+                                                    " -DCMAKE_INSTALL_LIBDIR=lib"
                                                    )
 
     def install(self):


### PR DESCRIPTION
Since .lib files are not needed for running the executables, don't
install them in bin/, but in lib/. That way, they won't be
needlessly packaged.

DLLs count as runtime artifacts and thus still go into bin/ as
desired.